### PR TITLE
Add pytest-based allocator scenario tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenAI
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "patchwork"
+version = "0.1.0"
+description = "Allocator test suite"
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+test = [
+  "pytest>=8.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+# Copyright 2026 OpenAI
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+
+CANDIDATE_MODULES = ("allocator", "patchwork.allocator", "src.allocator")
+CANDIDATE_CALLABLES = ("allocate", "run", "run_allocator", "allocate_sessions")
+
+
+def _load_allocator_callable() -> Callable[[dict[str, Any]], dict[str, Any]] | None:
+    for module_name in CANDIDATE_MODULES:
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError:
+            continue
+
+        for fn_name in CANDIDATE_CALLABLES:
+            fn = getattr(module, fn_name, None)
+            if callable(fn):
+                return fn
+    return None
+
+
+@pytest.fixture(scope="session")
+def allocator_fn() -> Callable[[dict[str, Any]], dict[str, Any]]:
+    fn = _load_allocator_callable()
+    if fn is None:
+        pytest.skip(
+            "allocator callable was not found. Expected one of: "
+            f"{CANDIDATE_MODULES} with function {CANDIDATE_CALLABLES}."
+        )
+    return fn
+
+
+def allocate_twice(
+    allocator_fn: Callable[[dict[str, Any]], dict[str, Any]], scenario: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    first = allocator_fn(deepcopy(scenario))
+    second = allocator_fn(deepcopy(scenario))
+    return first, second
+
+
+def iter_items(obj: Any, item_keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    if isinstance(obj, list):
+        return [x for x in obj if isinstance(x, dict)]
+    if isinstance(obj, dict):
+        for key in item_keys:
+            value = obj.get(key)
+            if isinstance(value, list):
+                return [x for x in value if isinstance(x, dict)]
+    return []
+
+
+def collect_values(obj: Any, target_key: str) -> list[Any]:
+    values: list[Any] = []
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k == target_key:
+                    values.append(v)
+                _walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                _walk(i)
+
+    _walk(obj)
+    return values

--- a/tests/test_allocator_lc.py
+++ b/tests/test_allocator_lc.py
@@ -1,0 +1,46 @@
+# Copyright 2026 OpenAI
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+from typing import Any
+
+from conftest import allocate_twice, collect_values, iter_items
+
+
+def test_allocator_lc_duplex_count13(allocator_fn) -> None:
+    """14.1: mmf_lc_duplex count=13 を再現し、ラック2モジュール・13セッション・MPOトランク4を検証。"""
+    scenario: dict[str, Any] = {
+        "case": "14.1",
+        "media": "mmf_lc_duplex",
+        "count": 13,
+        "racks": ["R01", "R02"],
+    }
+
+    result_first, result_second = allocate_twice(allocator_fn, scenario)
+
+    racks = iter_items(result_first, ("racks", "rack_allocations"))
+    assert len(racks) == 2
+    for rack in racks:
+        modules = iter_items(rack, ("modules", "line_modules", "patch_modules"))
+        assert len(modules) == 2
+
+    sessions = collect_values(result_first, "session_id")
+    assert len(sessions) == 13
+
+    trunks = [
+        t
+        for t in iter_items(result_first, ("trunks", "cables"))
+        if str(t.get("type", "")).lower().startswith("mpo")
+    ]
+    assert len(trunks) == 4
+
+    assert collect_values(result_first, "session_id") == collect_values(
+        result_second, "session_id"
+    )
+    assert collect_values(result_first, "cable_id") == collect_values(
+        result_second, "cable_id"
+    )

--- a/tests/test_allocator_mixed_u.py
+++ b/tests/test_allocator_mixed_u.py
@@ -1,0 +1,44 @@
+# Copyright 2026 OpenAI
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+from typing import Any
+
+from conftest import allocate_twice, collect_values, iter_items
+
+
+def test_allocator_mixed_same_u_mpo_and_mmf(allocator_fn) -> None:
+    """14.4: MPO3スロット+MMF1スロットで、同一U内混在配置を検証。"""
+    scenario: dict[str, Any] = {
+        "case": "14.4",
+        "racks": ["R01"],
+        "u_position": 14,
+        "mix": [
+            {"media": "mpo", "slots": 3},
+            {"media": "mmf_lc_duplex", "slots": 1},
+        ],
+    }
+
+    result_first, result_second = allocate_twice(allocator_fn, scenario)
+
+    placements = iter_items(result_first, ("placements", "slot_allocations", "modules"))
+    same_u = [p for p in placements if p.get("u") == 14 or p.get("u_position") == 14]
+
+    mpo_count = sum(
+        1 for p in same_u if str(p.get("media", "")).lower().startswith("mpo")
+    )
+    mmf_count = sum(1 for p in same_u if "mmf" in str(p.get("media", "")).lower())
+
+    assert mpo_count == 3
+    assert mmf_count == 1
+
+    assert collect_values(result_first, "session_id") == collect_values(
+        result_second, "session_id"
+    )
+    assert collect_values(result_first, "cable_id") == collect_values(
+        result_second, "cable_id"
+    )

--- a/tests/test_allocator_mpo.py
+++ b/tests/test_allocator_mpo.py
@@ -1,0 +1,55 @@
+# Copyright 2026 OpenAI
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+from typing import Any
+
+from conftest import allocate_twice, collect_values, iter_items
+
+
+def test_allocator_mpo12_count14(allocator_fn) -> None:
+    """14.2: mpo12 count=14 の検証（各ラック2スロット/14セッション/極性B/ポート整合）。"""
+    scenario: dict[str, Any] = {
+        "case": "14.2",
+        "media": "mpo12",
+        "count": 14,
+        "polarity": "B",
+        "racks": ["R01", "R02"],
+    }
+
+    result_first, result_second = allocate_twice(allocator_fn, scenario)
+
+    racks = iter_items(result_first, ("racks", "rack_allocations"))
+    assert len(racks) == 2
+    for rack in racks:
+        slots = iter_items(rack, ("slots", "slot_allocations"))
+        assert len(slots) == 2
+
+    sessions = collect_values(result_first, "session_id")
+    assert len(sessions) == 14
+
+    trunks = [
+        t
+        for t in iter_items(result_first, ("trunks", "cables"))
+        if str(t.get("type", "")).lower().startswith("mpo")
+    ]
+    assert trunks, "MPO trunk allocation must exist"
+    assert all(str(t.get("polarity", "")).upper() == "B" for t in trunks)
+
+    for trunk in trunks:
+        src_port = trunk.get("from_port") or trunk.get("src_port")
+        dst_port = trunk.get("to_port") or trunk.get("dst_port")
+        assert isinstance(src_port, int) and isinstance(dst_port, int)
+        assert 1 <= src_port <= 12
+        assert 1 <= dst_port <= 12
+
+    assert collect_values(result_first, "session_id") == collect_values(
+        result_second, "session_id"
+    )
+    assert collect_values(result_first, "cable_id") == collect_values(
+        result_second, "cable_id"
+    )

--- a/tests/test_allocator_utp.py
+++ b/tests/test_allocator_utp.py
@@ -1,0 +1,45 @@
+# Copyright 2026 OpenAI
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+from typing import Any
+
+from conftest import allocate_twice, collect_values, iter_items
+
+
+def test_allocator_utp_tail_share_for_6port_module(allocator_fn) -> None:
+    """14.3: R02:7, R03:2 を入力し、6ポートモジュールへのテールシェア割当を検証。"""
+    scenario: dict[str, Any] = {
+        "case": "14.3",
+        "media": "utp",
+        "demands": {"R02": 7, "R03": 2},
+        "module_ports": 6,
+        "allocation_mode": "tail_share",
+    }
+
+    result_first, result_second = allocate_twice(allocator_fn, scenario)
+
+    modules = [
+        m
+        for m in iter_items(result_first, ("modules", "patch_modules"))
+        if int(m.get("port_count", m.get("ports", 0))) == 6
+    ]
+    assert modules, "At least one 6-port module allocation is required"
+
+    tail_shared = [
+        m for m in modules if bool(m.get("tail_share") or m.get("shared_tail"))
+    ]
+    assert tail_shared, "Expected tail-share allocation on 6-port module"
+
+    assert len(collect_values(result_first, "session_id")) == 9
+
+    assert collect_values(result_first, "session_id") == collect_values(
+        result_second, "session_id"
+    )
+    assert collect_values(result_first, "cable_id") == collect_values(
+        result_second, "cable_id"
+    )


### PR DESCRIPTION
### Motivation
- Provide an executable, reproducible unit-test harness for the allocator to validate allocation patterns and deterministic ID generation across representative scenarios.
- Capture key real-world scenarios (14.1–14.4) as automated tests to detect regressions in module/trunk/port/placement logic.

### Description
- Add `pyproject.toml` to configure `pytest` and test dependencies and include license/SPDX/LLM-attribution header. 
- Add `tests/conftest.py` with a dynamic allocator entrypoint loader, helpers `allocate_twice`, `iter_items`, and `collect_values` to support scenario assertions and deterministic `session_id`/`cable_id` checks. 
- Add scenario tests: `tests/test_allocator_lc.py` (14.1 mmf_lc_duplex count=13), `tests/test_allocator_mpo.py` (14.2 mpo12 count=14), `tests/test_allocator_utp.py` (14.3 UTP tail-share into 6-port module), and `tests/test_allocator_mixed_u.py` (14.4 MPO+MMF in same U); each verifies structural expectations and deterministic IDs by running the allocator twice. 
- LLM involvement: the LLM created/modified the following files: `pyproject.toml`, `tests/conftest.py`, `tests/test_allocator_lc.py`, `tests/test_allocator_mpo.py`, `tests/test_allocator_utp.py`, `tests/test_allocator_mixed_u.py`; human review requested to verify allocator function names, scenario keys, and output key names match the concrete allocator API. 

### Testing
- Ran linter: `ruff check .` — all checks passed. 
- Formatting: `black tests` was run and reformatted test files, then `black --check tests` returned clean. 
- Type checking: `mypy tests` — success with no issues. 
- Byte-compile: `python -m compileall tests` — succeeded. 
- Unit tests: `pytest -q` — tests executed but were skipped because no allocator callable was discoverable (searches `allocator`, `patchwork.allocator`, `src.allocator` for `allocate|run|run_allocator|allocate_sessions`); pytest output: 4 skipped. 
- Note: `pre-commit run --all-files` could not be run in this environment (tool not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947c6848f88330a7258cb611f86d4e)