### PR TITLE
Scaffold Flask app with Upload→Trial→Save→Project Detail flow and SQLite schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- This file was created or modified with the assistance of an AI (Large Language Model). -->
+# Patchwork Flask Skeleton (spec 15.1 起点)
+
+Upload → Trial → Save → Project Detail の最小導線を持つ Flask アプリです。
+
+## セットアップ
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 起動
+
+```bash
+flask --app app run --debug
+```
+
+ブラウザ: `http://127.0.0.1:5000/upload`
+
+## 入力YAML例
+
+```yaml
+project_name: demo-project
+workers:
+  - alice
+  - bob
+tasks:
+  - task-1
+  - task-2
+  - task-3
+```
+
+## 出力例
+
+Trial実行後:
+- `trials` テーブルに trial データ保存
+- `session['trial_id']` に trial ID を保存
+
+Save実行後:
+- `projects` / `allocations` テーブルに保存
+- `exports/project_<id>.csv`
+- `exports/project_<id>.json`
+
+CSV例:
+
+```csv
+worker,task,score
+alice,task-1,1.0
+bob,task-2,0.9
+alice,task-3,1.0
+```
+
+JSON例:
+
+```json
+{
+  "project_name": "demo-project",
+  "summary": {"workers": 2, "tasks": 3, "allocations": 3},
+  "allocations": [
+    {"worker": "alice", "task": "task-1", "score": 1.0}
+  ]
+}
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Patchwork Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from flask import Flask, flash, redirect, render_template, request, session, url_for
+
+from db import get_db_connection, init_db
+from models import AllocationInput
+from services.allocator import run_trial_allocation
+from services.export import export_csv, export_result_json
+from services.render_svg import render_trial_svg
+
+BASE_DIR = Path(__file__).resolve().parent
+EXPORT_DIR = BASE_DIR / "exports"
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", "dev-secret")
+    app.config["DATABASE_PATH"] = str(BASE_DIR / "patchwork.db")
+    app.config["MAX_CONTENT_LENGTH"] = 1024 * 1024
+
+    init_db(app.config["DATABASE_PATH"])
+    EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+    @app.get("/")
+    def index():
+        return redirect(url_for("upload"))
+
+    @app.route("/upload", methods=["GET", "POST"])
+    def upload():
+        if request.method == "POST":
+            yaml_file = request.files.get("yaml_file")
+            if not yaml_file:
+                flash("YAMLファイルを選択してください", "error")
+                return redirect(url_for("upload"))
+            try:
+                payload = yaml_file.read().decode("utf-8")
+                parsed = AllocationInput.model_validate_yaml(payload)
+            except Exception as exc:  # noqa: BLE001
+                flash(f"入力エラー: {exc}", "error")
+                return redirect(url_for("upload"))
+
+            trial_result = run_trial_allocation(parsed)
+            with get_db_connection(app.config["DATABASE_PATH"]) as conn:
+                cursor = conn.execute(
+                    "INSERT INTO trials (name, input_yaml, result_json, status) VALUES (?, ?, ?, ?)",
+                    (
+                        parsed.project_name,
+                        payload,
+                        json.dumps(trial_result, ensure_ascii=False),
+                        "trial",
+                    ),
+                )
+                conn.commit()
+                session["trial_id"] = cursor.lastrowid
+
+            return redirect(url_for("trial"))
+
+        return render_template("upload.html")
+
+    @app.get("/trial")
+    def trial():
+        trial_id = session.get("trial_id")
+        if not trial_id:
+            flash("trial_id が見つかりません。先に Upload を実行してください", "error")
+            return redirect(url_for("upload"))
+
+        with get_db_connection(app.config["DATABASE_PATH"]) as conn:
+            row = conn.execute(
+                "SELECT id, name, result_json FROM trials WHERE id = ?", (trial_id,)
+            ).fetchone()
+        if not row:
+            flash("Trialデータが存在しません", "error")
+            return redirect(url_for("upload"))
+
+        result = json.loads(row["result_json"])
+        svg = render_trial_svg(result)
+        return render_template("trial.html", trial=row, result=result, svg=svg)
+
+    @app.post("/save")
+    def save():
+        trial_id = session.get("trial_id")
+        if not trial_id:
+            flash("保存対象の Trial がありません", "error")
+            return redirect(url_for("upload"))
+
+        with get_db_connection(app.config["DATABASE_PATH"]) as conn:
+            trial = conn.execute(
+                "SELECT * FROM trials WHERE id = ?", (trial_id,)
+            ).fetchone()
+            if not trial:
+                flash("Trialデータが存在しません", "error")
+                return redirect(url_for("upload"))
+
+            project_cursor = conn.execute(
+                "INSERT INTO projects (name, source_trial_id, status) VALUES (?, ?, ?)",
+                (trial["name"], trial_id, "saved"),
+            )
+            project_id = project_cursor.lastrowid
+
+            result = json.loads(trial["result_json"])
+            for entry in result.get("allocations", []):
+                conn.execute(
+                    "INSERT INTO allocations (project_id, worker, task, score) VALUES (?, ?, ?, ?)",
+                    (project_id, entry["worker"], entry["task"], float(entry["score"])),
+                )
+            conn.commit()
+
+        export_csv(result, EXPORT_DIR / f"project_{project_id}.csv")
+        export_result_json(result, EXPORT_DIR / f"project_{project_id}.json")
+        return render_template("save.html", project_id=project_id)
+
+    @app.get("/projects/<int:project_id>")
+    def project_detail(project_id: int):
+        with get_db_connection(app.config["DATABASE_PATH"]) as conn:
+            project = conn.execute(
+                "SELECT * FROM projects WHERE id = ?", (project_id,)
+            ).fetchone()
+            allocations = conn.execute(
+                "SELECT worker, task, score FROM allocations WHERE project_id = ? ORDER BY id",
+                (project_id,),
+            ).fetchall()
+
+        if not project:
+            flash("Projectが見つかりません", "error")
+            return redirect(url_for("upload"))
+
+        return render_template(
+            "project_detail.html", project=project, allocations=allocations
+        )
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/db.py
+++ b/db.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Patchwork Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+DDL_STATEMENTS = [
+    """
+    CREATE TABLE IF NOT EXISTS trials (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        input_yaml TEXT NOT NULL,
+        result_json TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'trial',
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS projects (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        source_trial_id INTEGER NOT NULL,
+        status TEXT NOT NULL DEFAULT 'saved',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY(source_trial_id) REFERENCES trials(id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS allocations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        project_id INTEGER NOT NULL,
+        worker TEXT NOT NULL,
+        task TEXT NOT NULL,
+        score REAL NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY(project_id) REFERENCES projects(id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_trials_created_at ON trials(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_projects_source_trial_id ON projects(source_trial_id)",
+    "CREATE INDEX IF NOT EXISTS idx_allocations_project_id ON allocations(project_id)",
+]
+
+
+def init_db(db_path: str) -> None:
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys=ON")
+        for ddl in DDL_STATEMENTS:
+            conn.execute(ddl)
+        conn.commit()
+
+
+@contextmanager
+def get_db_connection(db_path: str) -> Iterator[sqlite3.Connection]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Patchwork Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError, model_validator
+
+
+class AllocationInput(BaseModel):
+    project_name: str = Field(min_length=1)
+    workers: list[str] = Field(min_length=1)
+    tasks: list[str] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_unique(self) -> "AllocationInput":
+        if len(set(self.workers)) != len(self.workers):
+            raise ValueError("workers に重複があります")
+        if len(set(self.tasks)) != len(self.tasks):
+            raise ValueError("tasks に重複があります")
+        return self
+
+    @classmethod
+    def model_validate_yaml(cls, raw_yaml: str) -> "AllocationInput":
+        try:
+            payload: Any = yaml.safe_load(raw_yaml)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"YAML parse failed: {exc}") from exc
+
+        if not isinstance(payload, dict):
+            raise ValueError("YAMLのトップレベルはオブジェクトである必要があります")
+
+        try:
+            return cls.model_validate(payload)
+        except ValidationError as exc:
+            raise ValueError(exc.errors()) from exc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# This file was created or modified with the assistance of an AI (Large Language Model).
+Flask==3.1.0
+PyYAML==6.0.2
+pydantic==2.10.6
+pytest==8.3.4
+ruff==0.9.5
+mypy==1.15.0

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 Patchwork Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.

--- a/services/allocator.py
+++ b/services/allocator.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Patchwork Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+from models import AllocationInput
+
+
+def run_trial_allocation(data: AllocationInput) -> dict:
+    allocations = []
+    workers = data.workers
+    for i, task in enumerate(data.tasks):
+        worker = workers[i % len(workers)]
+        allocations.append(
+            {
+                "worker": worker,
+                "task": task,
+                "score": round(1.0 - ((i % len(workers)) * 0.1), 2),
+            }
+        )
+
+    return {
+        "project_name": data.project_name,
+        "summary": {
+            "workers": len(data.workers),
+            "tasks": len(data.tasks),
+            "allocations": len(allocations),
+        },
+        "allocations": allocations,
+    }

--- a/services/export.py
+++ b/services/export.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Patchwork Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+
+def export_csv(result: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fp:
+        writer = csv.DictWriter(fp, fieldnames=["worker", "task", "score"])
+        writer.writeheader()
+        for row in result.get("allocations", []):
+            writer.writerow(row)
+
+
+def export_result_json(result: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/services/render_svg.py
+++ b/services/render_svg.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Patchwork Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from __future__ import annotations
+
+
+def render_trial_svg(result: dict) -> str:
+    rows = result.get("allocations", [])
+    row_height = 30
+    height = 40 + (len(rows) * row_height)
+    blocks = [
+        '<svg xmlns="http://www.w3.org/2000/svg" width="900" height="{}">'.format(
+            height
+        ),
+        '<rect x="0" y="0" width="900" height="{}" fill="#f9fafb"/>'.format(height),
+    ]
+
+    for i, row in enumerate(rows):
+        y = 25 + i * row_height
+        blocks.append(
+            f'<text x="20" y="{y}" font-size="14" fill="#111827">{row["worker"]} → {row["task"]} (score={row["score"]})</text>'
+        )
+
+    blocks.append("</svg>")
+    return "".join(blocks)

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,22 @@
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# This file was created or modified with the assistance of an AI (Large Language Model). Review required for correctness, security, and licensing. #}
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Patchwork Trial App</title>
+  </head>
+  <body>
+    <h1>Patchwork Trial App</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <ul>
+          {% for category, message in messages %}
+            <li><strong>{{ category }}</strong>: {{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -1,0 +1,17 @@
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# This file was created or modified with the assistance of an AI (Large Language Model). Review required for correctness, security, and licensing. #}
+{% extends "base.html" %}
+{% block content %}
+<h2>Project Detail</h2>
+<p>project_id: {{ project['id'] }}</p>
+<p>name: {{ project['name'] }}</p>
+<table border="1" cellpadding="4">
+  <thead><tr><th>worker</th><th>task</th><th>score</th></tr></thead>
+  <tbody>
+    {% for row in allocations %}
+      <tr><td>{{ row['worker'] }}</td><td>{{ row['task'] }}</td><td>{{ row['score'] }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<a href="{{ url_for('upload') }}">Uploadに戻る</a>
+{% endblock %}

--- a/templates/save.html
+++ b/templates/save.html
@@ -1,0 +1,8 @@
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# This file was created or modified with the assistance of an AI (Large Language Model). Review required for correctness, security, and licensing. #}
+{% extends "base.html" %}
+{% block content %}
+<h2>Save</h2>
+<p>保存が完了しました。</p>
+<p><a href="{{ url_for('project_detail', project_id=project_id) }}">Project Detailへ進む</a></p>
+{% endblock %}

--- a/templates/trial.html
+++ b/templates/trial.html
@@ -1,0 +1,11 @@
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# This file was created or modified with the assistance of an AI (Large Language Model). Review required for correctness, security, and licensing. #}
+{% extends "base.html" %}
+{% block content %}
+<h2>Trial</h2>
+<p>trial_id: {{ trial['id'] }}</p>
+<div>{{ svg|safe }}</div>
+<form action="{{ url_for('save') }}" method="post">
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,10 @@
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# This file was created or modified with the assistance of an AI (Large Language Model). Review required for correctness, security, and licensing. #}
+{% extends "base.html" %}
+{% block content %}
+<h2>Upload</h2>
+<form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data">
+  <p><input type="file" name="yaml_file" accept=".yaml,.yml" required /></p>
+  <button type="submit">Trial 実行</button>
+</form>
+{% endblock %}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Patchwork Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from db import init_db
+
+
+def test_init_db_creates_tables(tmp_path) -> None:
+    db_path = tmp_path / "test.db"
+    init_db(str(db_path))
+    assert db_path.exists()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Patchwork Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from models import AllocationInput
+
+
+def test_model_validate_yaml_success() -> None:
+    raw = """
+project_name: demo
+workers: [alice, bob]
+tasks: [task1, task2]
+"""
+    data = AllocationInput.model_validate_yaml(raw)
+    assert data.project_name == "demo"
+    assert data.workers == ["alice", "bob"]
+
+
+def test_model_validate_yaml_duplicate_worker() -> None:
+    raw = """
+project_name: demo
+workers: [alice, alice]
+tasks: [task1]
+"""
+    try:
+        AllocationInput.model_validate_yaml(raw)
+        assert False, "expected ValueError"
+    except ValueError:
+        assert True


### PR DESCRIPTION
### Motivation
- Provide an initial, modular Flask application baseline rooted at spec 15.1 implementing the requested user flow and storage lifecycle. 
- Ensure persistent trial/project storage per spec 9.2 by bootstrapping SQLite schema on startup and offering export/inspection paths. 

### Description
- Added a minimal Flask app implementing routes Upload → Trial → Save → Project Detail, with trial state tracked via `session['trial_id']` and result persistence into a `trials` table; main entry is `app.py` and app factory `create_app()` initializes DB and export directories. 
- Implemented SQLite bootstrapping in `db.py` with `CREATE TABLE IF NOT EXISTS` DDL for `trials`, `projects`, and `allocations` and supporting indexes, plus `get_db_connection()` context manager. 
- Added YAML input model and validation in `models.py` using `pydantic` for field checks and duplicate detection, and a simple allocation algorithm (`services/allocator.py`), SVG rendering (`services/render_svg.py`), and CSV/JSON exports (`services/export.py`). 
- Added Jinja templates for the flow (`templates/base.html`, `upload.html`, `trial.html`, `save.html`, `project_detail.html`), `requirements.txt`, `README.md` with start/example docs, and two basic tests (`tests/test_db.py`, `tests/test_models.py`). 
- LLM involvement: the following files were created or modified with LLM assistance and include license/attribution headers: `README.md`, `app.py`, `db.py`, `models.py`, `requirements.txt`, `services/__init__.py`, `services/allocator.py`, `services/export.py`, `services/render_svg.py`, `templates/base.html`, `templates/upload.html`, `templates/trial.html`, `templates/save.html`, `templates/project_detail.html`, `tests/test_db.py`, and `tests/test_models.py`; please perform human review of schema conformance to spec 9.2 and allocation logic correctness/security before merge. 

### Testing
- Ran lint/format checks: `ruff check .` succeeded and `python3 -m black .` reformatted files then `python3 -m black --check .` succeeded. 
- Ran bytecode/compile check: `python3 -m compileall app.py db.py models.py services tests` succeeded. 
- Ran unit tests: `python3 -m pytest -q` failed during collection in this environment due to missing third-party packages (`PyYAML`, `pydantic`, `flask`) not available for install here. 
- Ran type checks: `mypy app.py db.py models.py services` reported missing imports/stubs for `flask`, `pydantic`, and `yaml` in this environment; this is expected until dependencies/stubs are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947c89c26c83308aa7899e070f3981)